### PR TITLE
Add dotenv support

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,3 +1,6 @@
+// load environment variables from .env file
+require('dotenv').config()
+
 module.exports = {
   e2e: {
     setupNodeEvents(on, config) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.8.1"
+        "cypress": "^12.8.1",
+        "dotenv": "^16.0.3"
       }
     },
     "node_modules/@colors/colors": {
@@ -643,6 +644,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -2387,6 +2397,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "dev": true
     },
     "ecc-jsbn": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^12.8.1"
+    "cypress": "^12.8.1",
+    "dotenv": "^16.0.3"
   }
 }


### PR DESCRIPTION
Add support for the dotenv, allowing for the loading of environment variables from a .env file.

This is a common best practice for managing sensitive information, such as API keys and credentials, and ensures that these values are not hard-coded into the application code.