### PR TITLE
Add OAuth login support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,21 @@
+#
+# copy this file to .env and modify the values appropriately
+#
+
+# base URL of the application being tested
+BASE_URL=https://example.com/
+
+# Enable or disable OAuth authentication
+OAUTH_ENABLED=true
+
+# OAuth client ID for authentication
+OAUTH_CLIENT_ID=00000000-0000-0000-0000-000000000000
+
+# OAuth client secret for authentication
+OAUTH_CLIENT_SECRET=00000000-0000-0000-0000-000000000000
+
+# scopes for OAuth authentication
+OAUTH_SCOPE=openid email profile
+
+# URL for OAuth token endpoint
+OAUTH_TOKEN_URL=https://login.example.com/oauth

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,6 +7,13 @@ module.exports = {
       // implement node event listeners here
     },
     baseUrl: 'https://seniors-journey-test.dev-dp.dts-stn.com/',
-    language: 'French'
+    language: 'French',
+    env: {
+      oauthClientId: process.env.OAUTH_CLIENT_ID,
+      oauthClientSecret: process.env.OAUTH_CLIENT_SECRET,
+      oauthEnabled: process.env.OAUTH_ENABLED === 'true',
+      oauthScope: process.env.OAUTH_SCOPE,
+      oauthTokenUrl: process.env.OAUTH_TOKEN_URL,
+    },
   },
 };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,25 +1,88 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+/**
+ * Intercepts network requests using Cypress intercept and adds an authorization header
+ * with a bearer token.
+ *
+ * @param {string} token - The bearer token to include in the authorization header.
+ * @returns {Cypress.Chainable} A chainable object representing the intercepted request.
+ */
+function interceptWithAuthorization(token) {
+  return cy.intercept('/**', ({ headers }) => {
+    headers['Authorization'] = `Bearer ${token}`
+  })
+}
+
+/**
+ * Checks if an access token is still valid based on its expiry timestamp.
+ *
+ * @param {number} accessTokenExpiry - The timestamp of the access token expiry in milliseconds since Unix epoch.
+ * @returns {boolean} - Returns true if the access token is still valid, false otherwise.
+ */
+function isAccessTokenValid(accessTokenExpiry) {
+  return Date.now() < accessTokenExpiry
+}
+
+/**
+ * Custom cypress command for logging in to a service account using OAuth 2.0 client credentials grant.
+ *
+ * This command requires the following environment variables to be set:
+ * - oauthClientId: The client ID for the OAuth 2.0 client credentials grant.
+ * - oauthClientSecret: The client secret for the OAuth 2.0 client credentials grant.
+ * - oauthTokenUrl: The token endpoint URL for the OAuth 2.0 client credentials grant.
+ * - oauthScope (optional): The OAuth 2.0 scope(s) for the access token.
+ *
+ * @throws {Error} If any of the required environment variables are not defined.
+ * @returns {Cypress.Chainable<string>} A chainable object representing the bearer token.
+ */
+Cypress.Commands.add('getBearerToken', () => {
+  const { oauthAccessToken, oauthAccessTokenExpiry, oauthClientId, oauthClientSecret, oauthScope, oauthTokenUrl } = Cypress.env()
+
+  if (!oauthClientId) { throw new Error('OAuth client ID is not defined') }
+  if (!oauthClientSecret) { throw new Error('OAuth client secret is not defined') }
+  if (!oauthTokenUrl) { throw new Error('OAuth token URL is not defined') }
+
+  if (oauthAccessToken && oauthAccessTokenExpiry && isAccessTokenValid(oauthAccessTokenExpiry)) {
+    return cy.wrap(oauthAccessToken, { log: false })
+  }
+
+  cy.log(`Acquiring OAuth token for service account: [${oauthClientId}]`)
+
+  return cy.request({
+    url: oauthTokenUrl,
+    method: 'POST',
+    log: false,
+    form: true,
+    body: {
+      grant_type: 'client_credentials',
+      client_id: oauthClientId,
+      client_secret: oauthClientSecret,
+      scope: oauthScope,
+    },
+  })
+  .then(({ body }) => {
+    const oauthAccessToken = body['access_token']
+    const oauthAccessTokenExpiry = Date.now() + body['expires_in'] * 1000
+
+    Cypress.env({ oauthAccessToken, oauthAccessTokenExpiry })
+
+    return oauthAccessToken
+  })
+})
+
+/**
+ * Overwrites the `visit` command to include an authorization header with a bearer token
+ * obtained from a login request, if OAuth is enabled.
+ *
+ * @param {Cypress.VisitFunction} originalFn - The original `visit` function.
+ * @param {string} url - The URL to visit.
+ * @param {Cypress.VisitOptions} options - Options to customize the visit.
+ * @returns {Cypress.Chainable} A chainable object representing the intercepted request.
+ */
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  if (!Cypress.env('oauthEnabled')) {
+    return originalFn(url, options)
+  }
+
+  return cy.getBearerToken()
+    .then(token => interceptWithAuthorization(token))
+    .then(() => originalFn(url, options))
+})


### PR DESCRIPTION
Add a new `login` command to Cypress with support for OAuth authentication. The command acquires an OAuth token using the provided client ID, client secret, and token URL. The token is then stored in the `Cypress.env` object as `oauthAccessToken`.

The command will throw an error if any of the required environment variables (`oauthClientId`, `oauthClientSecret`, and `oauthTokenUrl`) are not defined.

This feature will be useful for any tests that require authentication with an OAuth server.
