### PR TITLE
Fix Cypress Github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,3 +10,9 @@ jobs:
       # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v5
+        env:
+          OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          OAUTH_ENABLED: ${{ secrets.OAUTH_ENABLED }}
+          OAUTH_SCOPE: ${{ secrets.OAUTH_SCOPE }}
+          OAUTH_TOKEN_URL: ${{ secrets.OAUTH_TOKEN_URL }}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -15,5 +15,6 @@ module.exports = {
       oauthScope: process.env.OAUTH_SCOPE,
       oauthTokenUrl: process.env.OAUTH_TOKEN_URL,
     },
+    userAgent: 'cypress/12.x'
   },
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "cypress": "cypress open",
+    "cypress": "npx cypress open",
     "firefox": "npx cypress run --browser firefox",
     "edge": "npx cypress run --browser edge",
     "chrome": "npx cypress run --browser chrome"


### PR DESCRIPTION
This commit fixes the Cypress Github action and headless tests by adding environment variables to the action, and a user-agent header to `cypress.config.js`.
